### PR TITLE
docs: reorganize README and add testing.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,316 @@
+# Boson Project FAQ
+
+Frequently asked questions about Boson Project.
+
+## What is Boson Project?
+
+Boson Project is a collection of tooling that enables developers to create and
+run functions as a Knative Service on Kubernetes. The major components of this
+project are listed here.
+
+* Function runtimes for Go, Node.js and Quarkus
+* Buildpacks for Go, Node.js and Quarkus
+* A `faas` CLI for initializing, creating and deploying functions as a Knative
+  Service
+* Knative Serving and Eventing as the platform on which it all runs
+
+## How mature is the Boson Project?
+
+Boson started out as a proof of concept project in mid 2020 and is currently
+under active development. We anticipate a limited Developer Preview in late fall
+2020.
+
+## How do I Use Boson Functions?
+
+For Function projects, a developer uses the `faas` CLI for project creation and
+deployment. To get started using Boson Functions now, please follow the
+[step by step tutorial](tutorial.md).
+
+### How does a Function Project get built?
+
+The `faas` CLI uses the CNCF Buildpack API to create a container image. The
+[buildpacks](https://github.com/boson-project/buildpacks/)
+are based on and extend Red Hat UBI 8 and UBI 8 Minimal images.
+
+![Boson Project Build](assets/init-build.png)
+
+### How is a Function Project deployed?
+
+Once a container image has been created, the CLI can deploy it as a Knative
+service on the cluster currently active in `~/.kube/config`.
+
+Future development will also have a second process running in the image. This is
+the Boson `grid`. This service, has REST endpoints for platform-agnostic
+[Subscription](https://github.com/cloudevents/spec/blob/master/subscriptions-api.md)
+and [Discovery](https://github.com/cloudevents/spec/blob/master/discovery.md)
+APIs, allowing the function to subscribe to event sources upon startup.
+
+![Boson Function Runtime](assets/function-runtime.png)
+
+## How are Boson Functions invoked?
+
+Boson Functions are deployed as Knative Services, so they are invoked by simple
+HTTP requests. These HTTP requests may be sent directly from external sources
+via Kubernetes ingress, or they may be invoked from within the cluster by the
+Knative Event Broker. All function runtimes currently expose a raw HTTP invocation
+capability as well as a `CloudEvent` invocation signature.
+
+## How do Boson Functions subscribe to events?
+Events in the Knative platform are exposed to Boson Functions via Knative
+`Triggers`. A function project expresses its interest in events of a specific
+type or from a specific source via a `Trigger`. Subsequently, the Knative
+event Broker will route these events to a function, invoking it with an HTTP
+POST request comprised of a `CloudEvent`.
+
+## What is the tooling and architecture for the Boson Project?
+
+The primary tooling used by a function developer is the
+[`faas` CLI](https://github.com/boson-project/faas). Developers use this CLI to
+create new function projects and deploy them to a Kubernetes cluster running
+Knative Serving and Eventing. During deployment, the developer's function code
+is combined with a runtime framework (for example Quarkus or Node.js) and a
+platform proxy API (aka [`grid`](https://github.com/boson-project/grid)) using
+the CNCF Buildpack APIs to create a runnable OCI container.
+
+
+## What does a Boson Function look like?
+
+Boson Functions are simply that - functions. They are written in either Go,
+Node.js or Java/Quarkus. The Boson `faas` CLI can create a Boson Function
+project using a
+[template](https://github.com/boson-project/faas/tree/develop/templates) which
+provides the overall structure for your function. Here is a simple example
+function, written in Node.js.
+
+```js
+function handleCustomer(customer, context) {
+  if (!customer) {
+    return new Error('No customer received');
+  }
+  context.log.debug(`Cloud event received: ${JSON.stringify(context.cloudevent)}`);
+  // do something with `customer`
+  const result = processCustomer(customer);
+
+  return {
+      customer,
+      result
+  }
+};
+
+module.exports = handleCustomer;
+```
+
+This function is expected to be invoked with data from a `CloudEvent` as the
+first parameter. To access the raw HTTP request, there are properties on the
+`context` object that is provided. For example,
+
+```js
+function invoke(context) {
+  context.log.info(`Handling HTTP ${context.httpVersion} request`);
+  if (context.method === 'POST') {
+    return handlePost(context);
+  } else if (context.method === 'GET') {
+    return handleGet(context);
+  } else {
+    return { statusCode: 451, statusMessage: 'Unavailable for Legal Reasons' };
+  }
+}
+
+function handlePost(context) {
+  return {
+    body: context.body,
+    name: context.body.name
+  }
+};
+
+function handleGet(context) {
+  return {
+    query: context.query,
+    name: context.query.name,
+  }
+};
+```
+
+A Boson Function project may contain more than a single function. Howver, only the
+function exported from `index.js` will be invoked.
+
+### Other Examples
+
+<details>
+<summary>Quarkus Example</summary>
+  
+  ```java
+  package com.example;
+  
+  public class Functions {
+    // To expose the function just add `@Funq` annotation.
+    // The input/output type should be either primitive type or Java Bean.
+    @Funq
+    public String toLowerCase(String val) {
+        return val.toLowerCase();
+    }
+  }
+  ```
+  
+</details>
+
+<details>
+<summary>Go Raw HTTP Example</summary>
+  
+  ```go
+  package function
+
+  import (
+    "context"
+    "fmt"
+    "net/http"
+    "os"
+  )
+
+  // The function has to be named `Handle` and it has to be in the`function` package.
+  // Handle an HTTP Request.
+  // The `ctx` param is optional.
+  func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
+
+    res.Header().Add("Content-Type", "text/plain")
+    res.Header().Add("Content-Length", "3")
+    res.WriteHeader(200)
+
+    _, err := fmt.Fprintf(res, "OK\n")
+    if err != nil {
+      fmt.Fprintf(os.Stderr, "error or response write: %v", err)
+    }
+  }
+  ```
+  
+</details>
+
+<details>
+<summary>Go CloudEvent Example</summary>
+  
+  ```go
+  package function
+
+  import (
+    "context"
+    "fmt"
+    "os"
+
+    cloudevents "github.com/cloudevents/sdk-go/v2"
+  )
+
+  // The function has to be named `Handle` and it has to be in the`function` package.
+  // Handle a CloudEvent.
+  // Valid fn signatures are:
+  // * func()
+  // * func() error
+  // * func(context.Context)
+  // * func(context.Context) protocol.Result
+  // * func(event.Event)
+  // * func(event.Event) protocol.Result
+  // * func(context.Context, event.Event)
+  // * func(context.Context, event.Event) protocol.Result
+  // * func(event.Event) *event.Event
+  // * func(event.Event) (*event.Event, protocol.Result)
+  // * func(context.Context, event.Event) *event.Event
+  // * func(context.Context, event.Event) (*event.Event, protocol.Result)
+  func Handle(ctx context.Context, event cloudevents.Event) error {
+    if err := event.Validate(); err != nil {
+      fmt.Fprintf(os.Stderr, "invalid event received. %v", err)
+      return err
+    }
+    fmt.Printf("%v\n", event)
+    return nil
+  }
+  ```
+  
+</details>
+
+## Can I run Boson Functions on OpenShift?
+
+The Boson Project is designed to work on OpenShift 4.6.x with the Serverless
+Operator installed, or Kubernetes with Knative Serving and Eventing.
+
+
+## When will Boson Project be ready for general usage?
+
+A Developer Preview for OpenShift Serverless customers will be available in
+early to mid November. For vanilla Kubernetes/Knative the most recent version of
+the CLI can be obtained on our
+[releases page](https://github.com/boson-project/faas/releases/).
+
+## How does this project relate to Knative?
+
+Knative is the target deployment platform for Boson Functions.
+
+## What are the application types and use cases/user stories for Boson Functions?
+
+There are varieties of application types and user stories that could be acheived using Functions.
+Even Driven is the pattern that is at heart of the Functions and any Event Driven architecture could benefit from it.
+Some examples are:
+  - E-Commerce website:
+     - Function for Authentication that could show a personalized page.
+     - Function for cart management
+     - Function for payment management
+     - Function for Recommendation
+     - Cashless Payment System
+
+  - Media File Processing:
+    - Change the format of Files
+    - Generating thumbnails version of images
+    - Uploading thumbnails version of images to profile/dashboard
+
+  - Data Transformation
+    - Adding metadata to existing data
+    - Combining data from another source
+    - Converting the format of the data
+    - Restructuring the data
+    - Normalization of the data
+
+ - Scheduled Jobs
+ - ChatBot
+ - IoT backend
+ - notification based.
+ - Automation Tasks
+    - Content Creator
+ - Machine Learning data analytics
+ - Stream processing
+
+## Can I write stateful functions?
+
+Currently Boson Functions only offer Stateless functions but we would be adding
+Stateful Functions in the near future.
+
+## What languages/framework can I use for my functions?
+
+Boson Functions provides buildpacks for Quarkus, Node.js and Go for now with
+plans for Python, Spring Boot, Rust in the near future.
+
+## What events can trigger/call these functions?
+
+Boson Functions offers support for HTTP invocation, and
+[`CloudEvents`](https://cloudevents.io/) invocations.
+
+## Who is behind Boson Project?
+
+Boson Project is backed by Red Hat.
+
+
+//TODO
+
+## Does functions built using boson-project on any Kubernetes ? 
+## What restrictions would apply to the functions code?
+## How can I do logging in these distributed functions?
+## Would I be able to share code across my functions?
+## How would I monitor these functions?
+## How will I manage these functions?
+## Would I be able to access the infrastructure where these functions would run?
+## How would these functions secure my code?
+## Would I be able to use threads in these functions?
+## What are the best practices for working with Functions?
+## How does this project relate to KEDA ?
+## Can I build functions using this project and run on Azure Platform?
+## Can I build functions using this project and run on AWS?
+## How different this project is from Azure Functions?
+## How different this project is from AWS Lambda?
+

--- a/README.md
+++ b/README.md
@@ -1,294 +1,51 @@
-# Boson Project FAQ
-Frequently asked questions about Boson Project.
+# Boson Project
 
-## What is Boson Project?
 Boson Project is a collection of tooling that enables developers to create and
-run functions as a Knative Service on Kubernetes. The major components of this
-project are listed here.
+run Functions on Kubernetes as a Knative service. Boson exposes Function
+templates capable of responding to CloudEvents produced by Knative Eventing, or
+simple HTTP functions.
 
-* Function runtimes for Go, Node.js and Quarkus
-* Buildpacks for Go, Node.js and Quarkus
-* A `faas` CLI for initializing, creating and deploying functions as a Knative Service
-* Knative Serving and Eventing as the platform on which it all runs
-
-## How mature is the Boson Project?
-Boson started out as a proof of concept project in mid 2020 and is currently under
-active development. We anticipate a limited Developer Preview in late fall 2020.
-
-## Tooling and Architecture
-
-The primary tooling used by a function developer is the
-[`faas` CLI](https://github.com/boson-project/faas). Developers use this CLI to create
-new function projects and deploy them to a Kubernetes cluster running Knative Serving
-and Eventing. During deployment, the developer's function code is combined with a runtime
-framework (for example Quarkus or Node.js) and a platform proxy API
-(aka [`grid`](https://github.com/boson-project/grid)) using the CNCF Buildpack APIs to
-create a runnable OCI container.
+This repository is a directory of information and resources for the project.
 
 ## Using Boson Functions
 
-For Function projects, a developer uses the `faas` CLI for project creation and
-deployment. To get started using Boson Functions now, please follow the
-[step by step tutorial](tutorial.md).
+To get started using Boson Functions follow the
+[step by step tutorial](tutorial.md). For OpenShift Serverless Functions Test
+Day, please follow the [Test Day Guide](testing.md)
 
-### Function Builds
+### Feedback
 
-The `faas` CLI uses the CNCF Buildpack API to create a container image. The
-[buildpacks](https://github.com/boson-project/buildpacks/)
-are based on and extend Red Hat UBI 8 and UBI 8 Minimal images.
+If you encounter a bug, usability issue, or have other feedback to provide,
+please feel free to
+[create an issue](https://github.com/boson-project/functions/issues).
 
-![Boson Project Build](assets/init-build.png)
+## Components
 
-### Function Deployments
+The major components of the Boson Project are:
 
-Once a container image has been created, the CLI can deploy it as a Knative service
-on the cluster currently active in `~/.kube/config`.
-
-Future development will also have a second process running in the image. This is the
-Boson `grid`. This service, has REST endpoints for platform-agnostic
-[Subscription](https://github.com/cloudevents/spec/blob/master/subscriptions-api.md) and
-[Discovery](https://github.com/cloudevents/spec/blob/master/discovery.md) APIs, allowing
-the function to subscribe to event sources upon startup.
-
-![Boson Function Runtime](assets/function-runtime.png)
-
-## How are Boson Functions invoked?
-Boson Functions are deployed as Knative Services, so they are invoked by simple
-HTTP requests. These HTTP requests may be sent directly from external sources
-via Kubernetes ingress, or they may be invoked from within the cluster by the
-Knative Event Broker. All function runtimes currently expose a raw HTTP invocation
-capability as well as a `CloudEvent` invocation signature.
-
-## How do Boson Functions subscribe to events?
-Events in the Knative platform are exposed to Boson Functions via Knative
-`Triggers`. A function project expresses its interest in events of a specific
-type or from a specific source via a `Trigger`. Subsequently, the Knative
-event Broker will route these events to a function, invoking it with an HTTP
-POST request comprised of a `CloudEvent`.
-
-## What does a Boson Function look like?
-Boson Functions are simply that - functions. They are written in either Go,
-Node.js or Java/Quarkus. The Boson `faas` CLI can create a Boson Function
-project using a [template](https://github.com/boson-project/faas/tree/develop/templates)
-which provides the overall structure for your function. Here is a simple example
-function, written in Node.js.
-
-```js
-module.exports = async function (context) {
-  if (!context.cloudevent) {
-    return Promise.reject(new Error('No cloud event received'));
-  }
-  context.log.info(`Cloud event received: ${JSON.stringify(context.cloudevent)}`);
-  return new Promise((resolve, reject) => {
-    setTimeout(_ => resolve({ data: context.cloudevent.data }), 500);
-  });
-};
-```
-
-This function is from the default template used when creating a Node.js project using
-the `faas` CLI and is expected to be invoked with a `CloudEvent`. To access the raw HTTP
-request, there are properties on the `context` object that is provided. For example,
-
-```js
-function invoke(context) {
-  context.log.info(`Handling HTTP ${context.httpVersion} request`);
-  if (context.method === 'POST') {
-    return handlePost(context);
-  } else if (context.method === 'GET') {
-    return handleGet(context);
-  } else {
-    return { statusCode: 451, statusMessage: 'Unavailable for Legal Reasons' };
-  }
-}
-
-function handlePost(context) {
-  return {
-    body: context.body,
-    name: context.body.name
-  }
-};
-
-function handleGet(context) {
-  return {
-    query: context.query,
-    name: context.query.name,
-  }
-};
-```
-
-A Boson Function project may contain more than a single function. Howver, only the
-function exported from `index.js` will be invoked.
-
-### Other Examples
-
-<details>
-<summary>Quarkus Example</summary>
-  
-  ```java
-  package com.example;
-  
-  public class Functions {
-    // To expose the function just add `@Funq` annotation.
-    // The input/output type should be either primitive type or Java Bean.
-    @Funq
-    public String toLowerCase(String val) {
-        return val.toLowerCase();
-    }
-  }
-  ```
-  
-</details>
-
-<details>
-<summary>Go Raw HTTP Example</summary>
-  
-  ```go
-  package function
-
-  import (
-    "context"
-    "fmt"
-    "net/http"
-    "os"
-  )
-
-  // The function has to be named `Handle` and it has to be in the`function` package.
-  // Handle an HTTP Request.
-  // The `ctx` param is optional.
-  func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
-
-    res.Header().Add("Content-Type", "text/plain")
-    res.Header().Add("Content-Length", "3")
-    res.WriteHeader(200)
-
-    _, err := fmt.Fprintf(res, "OK\n")
-    if err != nil {
-      fmt.Fprintf(os.Stderr, "error or response write: %v", err)
-    }
-  }
-  ```
-  
-</details>
-
-<details>
-<summary>Go CloudEvent Example</summary>
-  
-  ```go
-  package function
-
-  import (
-    "context"
-    "fmt"
-    "os"
-
-    cloudevents "github.com/cloudevents/sdk-go/v2"
-  )
-
-  // The function has to be named `Handle` and it has to be in the`function` package.
-  // Handle a CloudEvent.
-  // Valid fn signatures are:
-  // * func()
-  // * func() error
-  // * func(context.Context)
-  // * func(context.Context) protocol.Result
-  // * func(event.Event)
-  // * func(event.Event) protocol.Result
-  // * func(context.Context, event.Event)
-  // * func(context.Context, event.Event) protocol.Result
-  // * func(event.Event) *event.Event
-  // * func(event.Event) (*event.Event, protocol.Result)
-  // * func(context.Context, event.Event) *event.Event
-  // * func(context.Context, event.Event) (*event.Event, protocol.Result)
-  func Handle(ctx context.Context, event cloudevents.Event) error {
-    if err := event.Validate(); err != nil {
-      fmt.Fprintf(os.Stderr, "invalid event received. %v", err)
-      return err
-    }
-    fmt.Printf("%v\n", event)
-    return nil
-  }
-  ```
-  
-</details>
-
-## Can I run my functions on OpenShift?
-The Boson Project is designed to work both on OpenShift with the Serverless
-Operator installed, or Kubernetes with Knative.
+* Function
+  [runtime templates](https://github.com/boson-project/faas/tree/main/templates)
+  for Go, Node.js and Quarkus. The runtime is responsible for managing incoming
+  CloudEvents or HTTP connections, and invoking the user function.
+* Buildpacks for Go, Node.js and Quarkus. The buildpacks are based on the CNCF
+  Buildpack specification and automate the process of converting a user's
+  function from source code into a runnable OCI image.
+* A CLI for initializing, creating and deploying functions as a Knative Service.
+  The CLI may be run standalone in vanilla Kubernetes environments, and it is
+  also available as a compiled plugin for `kn` in the OpenShift Serverless
+  Functions product.
+* A Kubernetes cluster with Knative Serving and Eventing installed
 
 ## Provisioning a Cluster
-If you don't already have an OpenShift instance with Serverless installed, or a
+
+If you don't already have an OpenShift cluster with Serverless installed, or a
 Kubernetes cluster with Knative Serving and Eventing, you can follow our
-[Getting Started with Kubernetes Guide](https://github.com/boson-project/faas/blob/develop/docs/getting_started_kubernetes.md) to provision a cluster for function deployment.
-Or follow our instructions for setting up a [kind cluster]('kind-setup.md') on
-your local system.
+[Getting Started with Kubernetes Guide](https://github.com/boson-project/faas/blob/develop/docs/getting_started_kubernetes.md)
+to provision a cluster for function deployment. Or for a quick and easy set up,
+follow our instructions for setting up a [kind cluster]('kind-setup.md') on your
+local system.
 
-## When will Boson Project be ready for general usage?
-There is not a fixed date at the moment for Boson Function availability, however
-we are hoping to provide a Developer Preview in the fall of 2020.
+## Support
 
-## How does this project relate to Knative ?
-Knative can be used as a target deployment for these functions
-
-## What are the application types and use cases/user stories for Boson Functions?
-There are varieties of application types and user stories that could be acheived using Functions.
-Even Driven is the pattern that is at heart of the Functions and any Event Driven architecture could benefit from it.
-Some examples are:
-  - E-Commerce website:
-     - Function for Authentication that could show a personalized page.
-     - Function for cart management
-     - Function for payment management
-     - Function for Recommendation
-     - Cashless Payment System
-
-  - Media File Processing:
-    - Change the format of Files
-    - Generating thumbnails version of images
-    - Uploading thumbnails version of images to profile/dashboard
-
-  - Data Transformation
-    - Adding metadata to existing data
-    - Combining data from another source
-    - Converting the format of the data
-    - Restructuring the data
-    - Normalization of the data
-
- - Scheduled Jobs
- - ChatBot
- - IoT backend
- - notification based.
- - Automation Tasks
-    - Content Creator
- - Machine Learning data analytics
- - Stream processing
-
-## Would I be able to write Stateful functions?
-Currently Boson Functions only offer Stateless functions but we would be adding Stateful Functions in the near future.
-
-## What languages/framework can I use to write my functions?
-Boson Functions provide buildpacks for Quarkus, Node.js and Go for now with plans for Python, Spring Boot, Rust in the near future.
-
-## What events can trigger/call these functions?
-Boson Functions offers support for HTTP event and [cloudevents](https://cloudevents.io/). 
-
-## Who is behind Boson Project?
 Boson Project are project from Red Hat that creates Functions based on Knative.
-
-
-//TODO
-
-## Does functions built using boson-project on any Kubernetes ? 
-## What restrictions would apply to the functions code?
-## How can I do logging in these distributed functions?
-## Would I be able to share code across my functions?
-## How would I monitor these functions?
-## How will I manage these functions?
-## Would I be able to access the infrastructure where these functions would run?
-## How would these functions secure my code?
-## Would I be able to use threads in these functions?
-## What are the best practices for working with Functions?
-## How does this project relate to KEDA ?
-## Can I build functions using this project and run on Azure Platform?
-## Can I build functions using this project and run on AWS?
-## How different this project is from Azure Functions?
-## How different this project is from AWS Lambda?
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ simple HTTP functions.
 
 This repository is a directory of information and resources for the project.
 
+## Quick links
+
+* [Frequently asked questions](FAQ.md)
+* [Tutorial](tutorial.md)
+* [Kind cluster setup](kind-setup.md)
+* [CLI Download](https://boson-project/faas/releases)
+
 ## Using Boson Functions
 
 To get started using Boson Functions follow the
 [step by step tutorial](tutorial.md). For OpenShift Serverless Functions Test
-Day, please follow the [Test Day Guide](testing.md)
+Day, please follow the [Test Day Guide](testing.md).
 
 ### Feedback
 
@@ -27,13 +34,14 @@ The major components of the Boson Project are:
   [runtime templates](https://github.com/boson-project/faas/tree/main/templates)
   for Go, Node.js and Quarkus. The runtime is responsible for managing incoming
   CloudEvents or HTTP connections, and invoking the user function.
-* Buildpacks for Go, Node.js and Quarkus. The buildpacks are based on the CNCF
-  Buildpack specification and automate the process of converting a user's
-  function from source code into a runnable OCI image.
-* A CLI for initializing, creating and deploying functions as a Knative Service.
-  The CLI may be run standalone in vanilla Kubernetes environments, and it is
-  also available as a compiled plugin for `kn` in the OpenShift Serverless
-  Functions product.
+* [Buildpacks](https://github.com/boson-project/buildpacks) for Go, Node.js and
+  Quarkus. The buildpacks are based on the CNCF Buildpack specification and
+  automate the process of converting a user's function from source code into a
+  runnable OCI image.
+* A [CLI](https://github.com/boson-project/faas) for initializing, creating and
+  deploying functions as a Knative Service. The CLI may be run standalone in
+  vanilla Kubernetes environments, and it is also available as a compiled plugin
+  for `kn` in the OpenShift Serverless Functions product.
 * A Kubernetes cluster with Knative Serving and Eventing installed
 
 ## Provisioning a Cluster

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,42 @@
+# Test Day
+
+The CLI may be used either as a plugin for `kn`, as distributed in OpenShift
+Serverless Functions, or on its own by downloading a binary for either Linux,
+OSX or Windows from the
+[project repository](https://github.com/boson-project/faas/releases/). For Test
+Day, please use the `kn` binary provided with OpenShift 4.6.x. This document is
+written assuming that you are using the `kn` CLI with Functions capabilities as
+provided by OpenShift Serverless. To follow along in this document using the
+`boson-project/faas` distribution, simply execute the commands _without_ the
+preceding `kn`. For example the following command which initializes a new
+Node.js Function project that responds to CloudEvents looks almost exactly the
+same.
+
+***OpenShift Serverless Functions***
+```
+kn faas init -l node -t events
+```
+
+***Boson Project***
+```
+faas init -l node -t events
+```
+
+## Prerequisites
+
+In order to use the CLI, the following prerequisites must be met.
+
+* You must have access to a Kubernetes cluster with Knative Serving and Eventing
+  installed. Ideally, this should be an instance of OpenShift version 4.6.x. It
+  is beyond the scope of this document to document enabling Knative Serving and
+  Eventing in a given Kubernetes `namespace`. Please see the
+  [OpenShift documentation](https://srvke-486--ocpdocs.netlify.app/openshift-enterprise/latest/serverless/installing_serverless/installing-openshift-serverless.html)
+  for additional resources.
+* You must have access to an image registry such as docker.io. Function project
+  images are pushed to a repository at this registry when they are created. If
+  you are using quay.io, you need to be sure to make the repository public the
+  first time you build time project.
+* You must have a Docker API compatible daemon running on your local system. See
+  the Docker ["Get Started"](https://www.docker.com/get-started) guide if you
+  need additional help.
+  

--- a/testing.md
+++ b/testing.md
@@ -27,9 +27,10 @@ faas init -l node -t events
 In order to use the CLI, the following prerequisites must be met.
 
 * You must have access to a Kubernetes cluster with Knative Serving and Eventing
-  installed. Ideally, this should be an instance of OpenShift version 4.6.x. It
-  is beyond the scope of this document to document enabling Knative Serving and
-  Eventing in a given Kubernetes `namespace`. Please see the
+  installed. Ideally, this should be an instance of OpenShift version 4.6.x. The
+  easiest way to do this is to use `clusterbot` on Slack. It is beyond the scope
+  of this document to document enabling Knative Serving and Eventing in a given
+  Kubernetes `namespace`. Please see the
   [OpenShift documentation](https://srvke-486--ocpdocs.netlify.app/openshift-enterprise/latest/serverless/installing_serverless/installing-openshift-serverless.html)
   for additional resources.
 * You must have access to an image registry such as docker.io. Function project
@@ -39,4 +40,3 @@ In order to use the CLI, the following prerequisites must be met.
 * You must have a Docker API compatible daemon running on your local system. See
   the Docker ["Get Started"](https://www.docker.com/get-started) guide if you
   need additional help.
-  

--- a/tutorial.md
+++ b/tutorial.md
@@ -8,9 +8,9 @@ editing, and deploying a Boson Function project.
 In order to follow along with this tutorial, you will need to have a few tools
 installed.
 
-* [oc](oc) or [kubectl](kubectl) CLI
-* [kn](kn) CLI
-* [Docker](docker) 
+* [oc][oc] or [kubectl][kubectl] CLI
+* [kn][kn] CLI
+* [Docker][docker] 
 
 [docker]: https://docs.docker.com/install/
 [oc]: https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands
@@ -183,17 +183,9 @@ HTTP requests.
 
 ### `faas deploy`
 
-To deploy the image to your cluster, use the `deploy` command.
+To deploy the image to your cluster, use the `deploy` command. You can also use
+this command to update a Function deployment after making changes locally.
 
 ```bash
 faas deploy
-```
-
-### `faas update`
-
-After editing the function source code and testing locally, you'll want to be
-able to redeploy the function. To do so, use the `update` command.
-
-```bash
-faas update
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -13,7 +13,7 @@ installed.
 * [Docker][docker] 
 
 [docker]: https://docs.docker.com/install/
-[oc]: https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands
+[oc]: https://docs.openshift.com/container-platform/4.6/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [kn]: https://knative.dev/docs/install/install-kn/
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,17 +1,24 @@
 # Boson Functions: A Step By Step Tutorial
+
 This document will walk you step by step through the process of creating,
 editing, and deploying a Boson Function project.
 
 ## Prerequisites
-In order to follow along with this tutorial, you will need to have a few
-tools installed. This project currently is limited to Linux.
 
-* [Docker](https://docs.docker.com/install/)
-* [oc](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) CLI
-* [kn](https://knative.dev/docs/install/install-kn/) CLI
+In order to follow along with this tutorial, you will need to have a few tools
+installed.
 
+* [oc](oc) or [kubectl](kubectl) CLI
+* [kn](kn) CLI
+* [Docker](docker) 
+
+[docker]: https://docs.docker.com/install/
+[oc]: https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands
+[kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[kn]: https://knative.dev/docs/install/install-kn/
 
 ## Cluster Setup
+
 To use Boson Functions, you'll need a Kubernetes cluster with Knative Serving
 and Eventing installed. If you have a recent version of OpenShift, you can
 simply install the Serverless Operator. If you don't have a cluster already,
@@ -20,16 +27,20 @@ these [step by step instructions](kind-setup.md) to install on your local
 machine.
 
 ## Boson Tooling
+
 The primary interface for Boson project is the `faas` CLI.
 [Download][faas-download] the most recent version and install it some place
 within your `$PATH`.
 
+[faas-download]: https://github.com/boson-project/faas/releases
+
 ```sh
 # Be sure to download the correct binary for your operating system
-curl -L -o - faas.gz https://github.com/boson-project/faas/releases/download/v0.7.0/faas_linux_amd64.gz | gunzip > faas && chmod 755 faas
+curl -L -o - faas.gz https://github.com/boson-project/faas/releases/download/v0.8.0/faas_linux_amd64.gz | gunzip > faas && chmod 755 faas
 sudo mv faas /usr/local/bin
 ```
 ## Configuring a Container Repository
+
 The unit of deployment in Boson Functions is an [OCI](https://opencontainers.org/)
 container image, typically referred to as a Docker container image.
 
@@ -55,6 +66,7 @@ export FAAS_REPOSITORY=docker.io/lanceball
 ```
 
 ## Creating a Project
+
 With your Knative enabled cluster up and running, you can now create a new
 Function Project. Let's start by creating a project directory. Function names
 in `faas` correspond to URLs at the moment, and there are some finicky cases
@@ -71,7 +83,7 @@ deploy the function as a Knative service.
 
 
 ```bash
-faas create -l node -y
+faas create -l node
 ```
 
 This will create a Node.js Function project in the current directory accepting
@@ -84,8 +96,8 @@ NAME            URL                                          LATEST             
 fn-example-io   http://fn-example-io.faas.127.0.0.1.nip.io   fn-example-io-ngswh-1   24s   3 OK / 3     True
 ```
 
-Clicking on the URL will take you to the running function in your cluster. You should see
-a simple response.
+Clicking on the URL will take you to the running function in your cluster. You
+should see a simple response.
 
 ```json
 {"query": {}}
@@ -99,17 +111,17 @@ curl "http://fn-example-io.faas.127.0.0.1.nip.io?name=tiger"
 ```
 
 ## Local Development
-The `faas create` command also results in a docker container that can be run locally
-with container ports mapped to localhost.
+The `faas create` command also results in a docker container that can be run
+locally with container ports mapped to localhost.
 
 ```bash
 faas run
 ```
 
-For day to day development of the function, you can also run it locally outside of a
-container. For this project, using Node.js, you have the following commands available.
-Note that to run this function locally, you will need Node.js 12.x or higher, and the
-corresponding npm.
+For day to day development of the function, you can also run it locally outside
+of a container. For this project, using Node.js, you have the following commands
+available. Note that to run this function locally, you will need Node.js 12.x or
+higher, and the corresponding npm.
 
 ```bash
 npm install # Installs all dependencies
@@ -118,9 +130,10 @@ npm run local # Execute the function on the local host
 ```
 
 ## Deploying to a Cluster - Step by Step
-With `faas create` you have already deployed to a cluster! But there was
-a lot of magic in that one command. Let's break it down step by step using
-the `faas CLI` to take each step in turn.
+
+With `faas create` you have already deployed to a cluster! But there was a lot
+of magic in that one command. Let's break it down step by step using the
+`faas` CLI to take each step in turn.
 
 First, let's delete the project we just created.
 
@@ -140,25 +153,26 @@ It might just take a little time for it to be removed.
 Now, let's clean up the current directory.
 
 ```bash
-rm -rf .* *
+rm -rf *
 ```
 
-### faas init
-To create a new project structure without building a container or deploying
-to a cluster, use the `init` command.
+### `faas init`
+
+To create a new project structure without building a container or deploying to a
+cluster, use the `init` command.
 
 ```bash
 faas init -l node -t http
 ```
 
-You can also create a Quarkus or a Golang project by providing `quarkus` or
-`go` respectively to the `-l` flag. To create a project with a template for
-CloudEvents, provide `events` to the `-t` flag. The `-y` flag, instructs the
-CLI to accept all of the defaults without prompting you for confirmation.
+You can also create a Quarkus or a Golang project by providing `quarkus` or `go`
+respectively to the `-l` flag. To create a project with a template for
+CloudEvents, provide `events` to the `-t` flag.
 
-### faas build
-To build the OCI container image for your function project, you can use
-the `build` command.
+### `faas build`
+
+To build the OCI container image for your function project, you can use the
+`build` command.
 
 ```bash
 faas build
@@ -167,19 +181,19 @@ faas build
 This creates a runnable container image that listens on port 8080 for incoming
 HTTP requests.
 
-### faas deploy
+### `faas deploy`
+
 To deploy the image to your cluster, use the `deploy` command.
 
 ```bash
 faas deploy
 ```
 
-### faas update
+### `faas update`
+
 After editing the function source code and testing locally, you'll want to be
 able to redeploy the function. To do so, use the `update` command.
 
 ```bash
 faas update
 ```
-
-[faas-download]: https://github.com/boson-project/faas/releases


### PR DESCRIPTION
This commit starts to reorganize the README document so that it's more
of a high-level overview with links to other documents and information.
Most of the text from the README had been moved to FAQ.md. The tutorial
has been modified to account for some minor changes in CLI usage. Finally
I have added a testing.md document which can be used to add test cases
for Test Day.

Signed-off-by: Lance Ball <lball@redhat.com>